### PR TITLE
feat: configure liquid

### DIFF
--- a/config/liquid.php
+++ b/config/liquid.php
@@ -2,6 +2,16 @@
 
 return [
     /**
+     * Whether to throw exceptions when a variable is not found in the context.
+     */
+    'strict_variables' => false,
+
+    /**
+     * Whether to throw exceptions when a filter is not found in the environment.
+     */
+    'strict_filters' => false,
+
+    /**
      * Extensions registered in the liquid environment.
      */
     'extensions' => [

--- a/config/liquid.php
+++ b/config/liquid.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    /**
+     * Extensions registered in the liquid environment.
+     */
+    'extensions' => [
+        \Keepsuit\LaravelLiquid\LaravelLiquidExtension::class,
+    ],
+];

--- a/src/LiquidServiceProvider.php
+++ b/src/LiquidServiceProvider.php
@@ -4,12 +4,14 @@ namespace Keepsuit\LaravelLiquid;
 
 use Clockwork\Clockwork;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Collection;
 use Illuminate\View\Factory;
 use Keepsuit\LaravelLiquid\Support\Clockwork\LiquidDataSource;
 use Keepsuit\LaravelLiquid\Support\LaravelLiquidFileSystem;
 use Keepsuit\LaravelLiquid\Support\LaravelTemplatesCache;
 use Keepsuit\Liquid\Environment;
 use Keepsuit\Liquid\EnvironmentFactory;
+use Keepsuit\Liquid\Extensions\Extension;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -18,7 +20,8 @@ class LiquidServiceProvider extends PackageServiceProvider
     public function configurePackage(Package $package): void
     {
         $package
-            ->name('laravel-liquid');
+            ->name('laravel-liquid')
+            ->hasConfigFile();
     }
 
     public function packageRegistered(): void
@@ -32,11 +35,17 @@ class LiquidServiceProvider extends PackageServiceProvider
                 compiler: $app->make('liquid.compiler')
             );
 
-            return EnvironmentFactory::new()
+            $environment = EnvironmentFactory::new()
                 ->setFilesystem($filesystem)
                 ->setTemplatesCache($templatesCache)
-                ->setRethrowErrors($app->hasDebugModeEnabled())
-                ->addExtension(new LaravelLiquidExtension);
+                ->setRethrowErrors($app->hasDebugModeEnabled());
+
+            Collection::make(config()->array('liquid.extensions', [LaravelLiquidExtension::class]))
+                ->filter(fn (mixed $extensionClass) => is_string($extensionClass) && class_exists($extensionClass))
+                ->map(fn (string $extensionClass): Extension => $app->make($extensionClass))
+                ->each(fn (Extension $extension) => $environment->addExtension($extension));
+
+            return $environment;
         });
 
         $this->app->singleton('liquid.environment', function (Application $app): Environment {

--- a/src/LiquidServiceProvider.php
+++ b/src/LiquidServiceProvider.php
@@ -43,7 +43,7 @@ class LiquidServiceProvider extends PackageServiceProvider
                 ->setStrictFilters(config()->boolean('liquid.strict_filters', false));
 
             Collection::make(config()->array('liquid.extensions', [LaravelLiquidExtension::class]))
-                ->filter(fn (mixed $extensionClass) => is_string($extensionClass) && class_exists($extensionClass))
+                ->filter(fn (mixed $extensionClass) => is_string($extensionClass) && class_exists($extensionClass) && is_subclass_of($extensionClass, Extension::class))
                 ->map(fn (string $extensionClass): Extension => $app->make($extensionClass))
                 ->each(fn (Extension $extension) => $environment->addExtension($extension));
 

--- a/src/LiquidServiceProvider.php
+++ b/src/LiquidServiceProvider.php
@@ -38,7 +38,9 @@ class LiquidServiceProvider extends PackageServiceProvider
             $environment = EnvironmentFactory::new()
                 ->setFilesystem($filesystem)
                 ->setTemplatesCache($templatesCache)
-                ->setRethrowErrors($app->hasDebugModeEnabled());
+                ->setRethrowErrors($app->hasDebugModeEnabled())
+                ->setStrictVariables(config()->boolean('liquid.strict_variables', false))
+                ->setStrictFilters(config()->boolean('liquid.strict_filters', false));
 
             Collection::make(config()->array('liquid.extensions', [LaravelLiquidExtension::class]))
                 ->filter(fn (mixed $extensionClass) => is_string($extensionClass) && class_exists($extensionClass))


### PR DESCRIPTION
Allow to configure liquid environment:
- `strict_variable`: enable strict variable mode
- `strict_filters`: enable strict filters mode
- `extensions`: allow to configure which extensions are registered in the environment

Fix #30 